### PR TITLE
Fix topic replication docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ services:
     image: 'bitnami/zookeeper:latest'
     ports:
      - '2181:2181'
-    environment
+    environment:
      - ALLOW_ANONYMOUS_LOGIN=yes
   kafka1:
     image: 'bitnami/kafka:latest'


### PR DESCRIPTION
**Description of the change**
This PR fixes an error on the topic replication docker-compose snippet in the README, missing `:` on line 8

**Benefits**
/
**Possible drawbacks**
/
**Applicable issues**
/
**Additional information**


